### PR TITLE
Selecting player order

### DIFF
--- a/src/main/java/com/EighthLight/app/Config.java
+++ b/src/main/java/com/EighthLight/app/Config.java
@@ -25,7 +25,6 @@ public class Config implements IConfig{
         createGameModes();
         createPlayerOrderOptions();
         setPlayers();
-        setPlayerOrder();
         setBoard();
     }
 
@@ -43,7 +42,6 @@ public class Config implements IConfig{
         playerOrder.put("2", null);
     }
 
-
     private void setPlayers() {
         ui.display(Constants.GAME_MODE_PROMPT);
         String userInput = ui.getInput();
@@ -52,6 +50,9 @@ public class Config implements IConfig{
             userInput = ui.getInput();
         }
         players.addAll(gameMode.get(userInput));
+        if (userInput.equals("2")) {
+            setPlayerOrder();
+        }
     }
 
     private void setPlayerOrder() {

--- a/src/main/java/com/EighthLight/app/Config.java
+++ b/src/main/java/com/EighthLight/app/Config.java
@@ -12,6 +12,7 @@ public class Config implements IConfig{
     private ArrayList<IPlayer> players = new ArrayList();
     private ArrayList<String> symbols = new ArrayList<>();
     private HashMap<String, ArrayList> gameMode = new HashMap<>();
+    private HashMap<String, Object> playerOrder = new HashMap<>();
     private IBoard board;
 
     public Config(IUserInterface ui) {
@@ -22,6 +23,7 @@ public class Config implements IConfig{
     private void setUpGame() {
         setSymbols();
         createGameModes();
+        createPlayerOrderOptions();
         setPlayers();
         setPlayerOrder();
         setBoard();
@@ -34,6 +36,11 @@ public class Config implements IConfig{
 
         gameMode.put("1", new ArrayList<>(Arrays.asList(playerOne, playerTwo)));
         gameMode.put("2", new ArrayList<>(Arrays.asList(playerOne, ai)));
+    }
+
+    private void createPlayerOrderOptions() {
+        playerOrder.put("1", null);
+        playerOrder.put("2", null);
     }
 
 
@@ -50,6 +57,10 @@ public class Config implements IConfig{
     private void setPlayerOrder() {
         ui.display(Constants.PLAYER_ORDER_PROMPT);
         String userInput = ui.getInput();
+        while (!(playerOrder.containsKey(userInput))) {
+            ui.display(Constants.INVALID_ORDER_PROMPT);
+            userInput = ui.getInput();
+        }
         if (userInput.equals("2")) {
             Collections.reverse(players);
         }

--- a/src/main/java/com/EighthLight/app/Constants.java
+++ b/src/main/java/com/EighthLight/app/Constants.java
@@ -16,4 +16,5 @@ public class Constants {
     public static final String INVALID_BOARD_SIZE_MSG = "That is not a valid board size. Try a number instead.";
     public static final String PLAYER_ORDER_PROMPT = "Who should have the first move? 1)Player One\n" +
                                                      "                                2)Player Two";
+    public static final String INVALID_ORDER_PROMPT = "Sorry that is not a valid choice, please try again.";
 }

--- a/src/main/java/com/EighthLight/app/Constants.java
+++ b/src/main/java/com/EighthLight/app/Constants.java
@@ -14,7 +14,7 @@ public class Constants {
     public static final String DUPLICATE_SYMBOL_ERROR_PROMPT = "Symbol already selected, please pick a different symbol.";
     public static final String INVALID_GAME_MODE_MSG = "That game type doesn't exist.";
     public static final String INVALID_BOARD_SIZE_MSG = "That is not a valid board size. Try a number instead.";
-    public static final String PLAYER_ORDER_PROMPT = "Who should have the first move? 1)Player One\n" +
-                                                     "                                2)Player Two";
+    public static final String PLAYER_ORDER_PROMPT = "Who should have the first move? 1)Player 1 (Human)\n" +
+                                                     "                                2)Player 2 (Computer)";
     public static final String INVALID_ORDER_PROMPT = "Sorry that is not a valid choice, please try again.";
 }

--- a/src/test/java/com/EighthLight/app/TestConfig.java
+++ b/src/test/java/com/EighthLight/app/TestConfig.java
@@ -18,20 +18,11 @@ public class TestConfig {
     private ArrayList<String> gameModeIncorrectInput;
     private ArrayList<String> boardSizeIncorrectInput;
     private ArrayList<String> playerOrderingTwoUserInputs;
-
-    @BeforeEach
-    public void setUp() {
-        defaultUserInputs = new ArrayList<>(Arrays.asList("X", "O", "1", "1", "1", "3"));
-        duplicateSymbolUserInputs = new ArrayList<>(Arrays.asList("X", "X", "O", "1", "1", "3"));
-        gameModeOneUserInputs = new ArrayList<>(Arrays.asList("X", "O", "1", "1","3"));
-        gameModeTwoUserInputs = new ArrayList<>(Arrays.asList("X", "O", "2", "1", "3"));
-        playerOrderingTwoUserInputs = new ArrayList<>(Arrays.asList("X", "O", "2", "2", "3"));
-        gameModeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "5", "1", "1", "3"));
-        boardSizeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "1", "", "Ten", "3"));
-    }
+    private ArrayList<String> playerOrderingIncorrectInput;
 
     @Test
     void promptsUserInCorrectOrder() {
+        defaultUserInputs = new ArrayList<>(Arrays.asList("X", "O", "1", "1", "1", "3"));
         MockUi ui = new MockUi(defaultUserInputs);
         new Config(ui);
 
@@ -50,6 +41,7 @@ public class TestConfig {
 
     @Test
     void promptsUserInCorrectOrderIfSymbolsAreDuplicates() {
+        duplicateSymbolUserInputs = new ArrayList<>(Arrays.asList("X", "X", "O", "1", "1", "3"));
         MockUi ui = new MockUi(duplicateSymbolUserInputs);
         new Config(ui);
 
@@ -68,6 +60,7 @@ public class TestConfig {
 
     @Test
     void invalidGameModeSelectionDisplaysAnErrorMessage() {
+        gameModeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "5", "1", "1", "3"));
         MockUi ui = new MockUi(gameModeIncorrectInput);
         new Config(ui);
 
@@ -86,6 +79,7 @@ public class TestConfig {
 
     @Test
     void invalidBoardSizeSelectionDisplaysAnErrorMessage() {
+        boardSizeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "1", "1", "Ten", "3"));
         MockUi ui = new MockUi(boardSizeIncorrectInput);
         new Config(ui);
 
@@ -103,8 +97,27 @@ public class TestConfig {
     }
 
     @Test
-    void gameMode1StartsWithTwoHumans() {
+    void invalidPlayerOrderSelectionDisplaysAWarningAndPrompt() {
+        playerOrderingIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "2", "7", "2", "3"));
+        MockUi ui = new MockUi(playerOrderingIncorrectInput);
+        new Config(ui);
 
+        ArrayList<String> prompts = new ArrayList(Arrays.asList(
+                Constants.PLAYER_ONE_SYMBOL_PROMPT,
+                Constants.PLAYER_TWO_SYMBOL_PROMPT,
+                Constants.GAME_MODE_PROMPT,
+                Constants.PLAYER_ORDER_PROMPT,
+                Constants.INVALID_ORDER_PROMPT,
+                Constants.BOARD_SIZE_PROMPT
+        ));
+        for (String prompt : prompts ) {
+            assertEquals(prompt, ui.getDisplayArgs().get(prompts.indexOf(prompt)));
+        }
+    }
+
+    @Test
+    void gameMode1StartsWithTwoHumans() {
+        gameModeOneUserInputs = new ArrayList<>(Arrays.asList("X", "O", "1", "1","3"));
         MockUi ui = new MockUi(gameModeOneUserInputs);
         Config config = new Config(ui);
 
@@ -115,7 +128,7 @@ public class TestConfig {
 
     @Test
     void gameMode2StartsWithAHumanAndAi() {
-
+        gameModeTwoUserInputs = new ArrayList<>(Arrays.asList("X", "O", "2", "1", "3"));
         MockUi ui = new MockUi(gameModeTwoUserInputs);
         Config config = new Config(ui);
 
@@ -126,6 +139,7 @@ public class TestConfig {
 
     @Test
     void selecting2ForPlayerOrderLetsPlayerTwoGoFirst() {
+        playerOrderingTwoUserInputs = new ArrayList<>(Arrays.asList("X", "O", "2", "2", "3"));
         MockUi ui = new MockUi(playerOrderingTwoUserInputs);
         Config config = new Config(ui);
         ArrayList<IPlayer> players = config.getPlayers();
@@ -136,6 +150,7 @@ public class TestConfig {
 
     @Test
     void usersCanSelectAnyTokenWhenSettingUpTheGameWithCorrectInput() {
+        defaultUserInputs = new ArrayList<>(Arrays.asList("X", "O", "1", "1", "1", "3"));
         MockUi ui = new MockUi(defaultUserInputs);
         Config config = new Config(ui);
         ArrayList symbols = config.getSymbols();
@@ -146,6 +161,7 @@ public class TestConfig {
 
     @Test
     void whenAUserSelectsABoardSizeANewBoardIsCreatedWithThatSize() {
+        defaultUserInputs = new ArrayList<>(Arrays.asList("X", "O", "1", "1", "1", "3"));
         MockUi ui = new MockUi(defaultUserInputs);
         Config config = new Config(ui);
         IBoard board = config.getBoard();

--- a/src/test/java/com/EighthLight/app/TestConfig.java
+++ b/src/test/java/com/EighthLight/app/TestConfig.java
@@ -22,7 +22,7 @@ public class TestConfig {
 
     @Test
     void promptsUserInCorrectOrder() {
-        defaultUserInputs = new ArrayList<>(Arrays.asList("X", "O", "1", "1", "1", "3"));
+        defaultUserInputs = new ArrayList<>(Arrays.asList("X", "O", "2", "1", "3"));
         MockUi ui = new MockUi(defaultUserInputs);
         new Config(ui);
 
@@ -41,7 +41,7 @@ public class TestConfig {
 
     @Test
     void promptsUserInCorrectOrderIfSymbolsAreDuplicates() {
-        duplicateSymbolUserInputs = new ArrayList<>(Arrays.asList("X", "X", "O", "1", "1", "3"));
+        duplicateSymbolUserInputs = new ArrayList<>(Arrays.asList("X", "X", "O", "1", "3"));
         MockUi ui = new MockUi(duplicateSymbolUserInputs);
         new Config(ui);
 
@@ -50,7 +50,6 @@ public class TestConfig {
                 Constants.PLAYER_TWO_SYMBOL_PROMPT,
                 Constants.DUPLICATE_SYMBOL_ERROR_PROMPT,
                 Constants.GAME_MODE_PROMPT,
-                Constants.PLAYER_ORDER_PROMPT,
                 Constants.BOARD_SIZE_PROMPT
         ));
         for (String prompt : prompts ) {
@@ -60,7 +59,7 @@ public class TestConfig {
 
     @Test
     void invalidGameModeSelectionDisplaysAnErrorMessage() {
-        gameModeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "5", "1", "1", "3"));
+        gameModeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "5", "1", "3"));
         MockUi ui = new MockUi(gameModeIncorrectInput);
         new Config(ui);
 
@@ -69,7 +68,6 @@ public class TestConfig {
                 Constants.PLAYER_TWO_SYMBOL_PROMPT,
                 Constants.GAME_MODE_PROMPT,
                 Constants.INVALID_GAME_MODE_MSG,
-                Constants.PLAYER_ORDER_PROMPT,
                 Constants.BOARD_SIZE_PROMPT
         ));
         for (String prompt : prompts ) {
@@ -79,7 +77,7 @@ public class TestConfig {
 
     @Test
     void invalidBoardSizeSelectionDisplaysAnErrorMessage() {
-        boardSizeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "1", "1", "Ten", "3"));
+        boardSizeIncorrectInput = new ArrayList<>(Arrays.asList("X", "O", "1", "Ten", "3"));
         MockUi ui = new MockUi(boardSizeIncorrectInput);
         new Config(ui);
 
@@ -87,7 +85,6 @@ public class TestConfig {
                 Constants.PLAYER_ONE_SYMBOL_PROMPT,
                 Constants.PLAYER_TWO_SYMBOL_PROMPT,
                 Constants.GAME_MODE_PROMPT,
-                Constants.PLAYER_ORDER_PROMPT,
                 Constants.BOARD_SIZE_PROMPT,
                 Constants.INVALID_BOARD_SIZE_MSG
         ));
@@ -135,6 +132,8 @@ public class TestConfig {
         ArrayList<IPlayer> players = config.getPlayers();
         assertTrue(players.get(0) instanceof Player);
         assertTrue(players.get(1) instanceof Ai);
+        assertEquals("X", players.get(0).getSymbol());
+        assertEquals("O", players.get(1).getSymbol());
     }
 
     @Test


### PR DESCRIPTION
Users can now select who goes first when playing against a computer opponent.
Users are warned when selecting an invalid option, and are prompted to pick again.